### PR TITLE
Add error boundaries

### DIFF
--- a/example.ts
+++ b/example.ts
@@ -51,13 +51,35 @@ setTimeout(() => {
 setTimeout(() => {
   timelessConsole.count(COUNT)
   timelessConsole.count(COUNT)
+  timelessConsole.purge() // removes above logs from the group
   timelessConsole.count(COUNT)
 }, 1235)
 
 setTimeout(() => {
-  autoConsoleGroup.count(COUNT)
   autoConsoleGroup.event('myEvent')
   autoConsoleGroup.label('myLabel')
-  autoConsoleGroup.count(COUNT)
-  autoConsoleGroup.timeEnd('myTimer')
+  // no group created, as we have not logged anything
 }, 1486)
+
+setTimeout(
+  autoConsoleGroup.errorBoundary(() => {
+    autoConsoleGroup.event('TypeError')
+    autoConsoleGroup.label('errorBoundary')
+    autoConsoleGroup.showTime(false)
+    autoConsoleGroup.collapsed(true)
+    autoConsoleGroup.info('This group is contained within an errorBoundary')
+    autoConsoleGroup.info('Errors are caught and logged to the consoleGroup')
+    throw new TypeError('Error in errorBoundary')
+  }),
+  1600,
+)
+
+setTimeout(() => {
+  autoConsoleGroup.label('myLabel') // reset as we changed it above
+  autoConsoleGroup.collapsed(false) // reset as we changed it above
+  autoConsoleGroup.showTime(true) // reset as we changed it above
+  autoConsoleGroup.count(COUNT)
+  autoConsoleGroup.event('endTimes') // this resets after each group
+  autoConsoleGroup.label('myLabel')
+  autoConsoleGroup.timeEnd('myTimer')
+}, 1700)

--- a/lib/consts.ts
+++ b/lib/consts.ts
@@ -9,3 +9,8 @@ export const BLACK = 'color: #1F1F1F;'
 export const WHITE = 'color: #E3E3E3;'
 
 export const DEFAULT = 'default'
+export const ERROR = 'error'
+export const WARN = 'warn'
+export const INFO = 'info'
+export const LOG = 'log'
+export const DEBUG = 'debug'

--- a/lib/wrap-object.ts
+++ b/lib/wrap-object.ts
@@ -13,7 +13,7 @@ type Target = {
 export const setValue = (target: Target) =>
   (key: string): ValueEntry => [
     key,
-    function (value: any): void {
+    function (value: string | boolean): void {
       target[key] = value
     },
   ]

--- a/test.js
+++ b/test.js
@@ -52,13 +52,23 @@ setTimeout(() => {
 setTimeout(() => {
   timelessConsole.count(COUNT)
   timelessConsole.count(COUNT)
+  timelessConsole.event('purge')
+  timelessConsole.purge() // removes above logs from the group
   timelessConsole.count(COUNT)
 }, 5)
 
+setTimeout(collapsedConsole.errorBoundary(() => {
+  collapsedConsole.count(COUNT)
+  collapsedConsole.event('TYPE_ERROR')
+  collapsedConsole.label('errorBoundary')
+  collapsedConsole.showTime(false)
+  collapsedConsole.count(COUNT)
+  throw new TypeError('Error in errorBoundary')
+}), 6)
+
 setTimeout(() => {
   autoConsoleGroup.count(COUNT)
-  autoConsoleGroup.event('myEvent')
+  autoConsoleGroup.event('endTimes')
   autoConsoleGroup.label('myLabel')
-  autoConsoleGroup.count(COUNT)
   autoConsoleGroup.timeEnd('myTimer')
-}, 6)
+}, 7)


### PR DESCRIPTION
Add `errorBoundy()` to enable catching errors into the current group.