### PR TITLE
Add error handling for undefined timer

### DIFF
--- a/example.ts
+++ b/example.ts
@@ -82,4 +82,5 @@ setTimeout(() => {
   console.event('endTimes') // this resets after each group
   console.label('myLabel')
   console.timeEnd('myTimer')
+  console.timeLog('foo', 'bar')
 }, 1700)

--- a/lib/auto-console-group.ts
+++ b/lib/auto-console-group.ts
@@ -140,6 +140,11 @@ export default function (options: AutoConsoleGroupOptions = {}): AutoConsoleGrou
   }
 
   function timeLog(label = DEFAULT, ...args: any[]): void {
+    if (!timers[label]) {
+      pushToConsoleQueue('timeLog', label, ...args)
+      return
+    }
+
     const now = performance.now() - timers[label]
     pushToConsoleQueue(LOG, `${label}: ${now} ms`, ...args)
   }

--- a/test.js
+++ b/test.js
@@ -74,4 +74,5 @@ setTimeout(() => {
   console.event('endTimes')
   console.label('myLabel')
   console.timeEnd('myTimer')
+  console.timeLog('myTimer', 'Logged with console.timeLog()')
 }, 7)


### PR DESCRIPTION
Add error handling for `undefined` timer via deferred call to `console.timeLog()` if timer is undefined. So we get the correct error message for the platform we are running on.